### PR TITLE
Working handshake + cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,19 +19,19 @@ async fn main() {
         .name("utun3".to_string())
         .bind_address("192.168.55.2".to_string())
         .netmask("255.255.255.0".to_string())
-        .source_id(0x01030108)
         .build();
 
     loop {
-        let mut buf = vec![0; 1504];
-        let connection_res = pack_leader.accept(&mut buf).await;
+        let connection_res = pack_leader.accept().await;
 
         tokio::spawn(async move {
             match connection_res {
-                Ok(mut conn) => conn.process().await,
+                Ok(conn) => println!("Conn ready! {conn})"),
                 Err(err) => eprintln!("\nConnection attempt failed: {:?}", err),
             }
         });
+
+        sleep(Duration::from_secs(1)).await;
     }
 }
 ```
@@ -41,7 +41,6 @@ async fn main() {
 async fn main() -> std::io::Result<()> {
     let mut client = BluefinClient::builder()
         .name("test_client".to_string())
-        .source_id(0x01020304)
         .build();
 
     let port = rand::thread_rng().gen_range(10000..50000);
@@ -53,6 +52,7 @@ async fn main() -> std::io::Result<()> {
         .await
         .expect("Failed to connect to host");
 
+    eprintln!("Conn ready! {conn}");
     Ok(())
 }
 ```

--- a/demo/client/src/bin/client.rs
+++ b/demo/client/src/bin/client.rs
@@ -5,7 +5,7 @@ use rand::Rng;
 use bluefin::hosts::client::BluefinClient;
 use tokio::time::sleep;
 
-const NUMBER_OF_CONNECTIONS: usize = 50;
+const NUMBER_OF_CONNECTIONS: usize = 10;
 
 #[tokio::main]
 async fn main() -> std::io::Result<()> {

--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -1,5 +1,3 @@
-use std::error;
-
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -48,4 +46,7 @@ pub enum BluefinError {
 
     #[error("No such waker.")]
     NoSuchWakerError,
+
+    #[error("Socket is not valid")]
+    InvalidSocketError,
 }

--- a/src/handshake/handshake.rs
+++ b/src/handshake/handshake.rs
@@ -5,115 +5,136 @@ use crate::{
         context::BluefinHost,
         error::BluefinError,
         header::{BluefinHeader, BluefinSecurityFields, BluefinTypeFields, PacketType},
-        packet::BluefinPacket,
+        packet::{BluefinPacket, Packet},
         serialisable::Serialisable,
     },
+    io::manager::Result,
     network::connection::Connection,
 };
 
-pub async fn bluefin_handshake_handle(conn: &mut Connection) -> Result<(), BluefinError> {
-    match conn.context.host_type {
-        BluefinHost::Client => bluefin_client_handshake_handler(conn).await,
-        BluefinHost::PackLeader => bluefin_packleader_handshake_handler(conn).await,
-        BluefinHost::PackFollower => bluefin_packfollower_handshake_handler(conn).await,
-    }
+pub(crate) struct HandshakeHandler<'a> {
+    conn: &'a mut Connection,
+    host: BluefinHost,
+    incoming_packet: Packet,
 }
 
-/// We have already parsed the client hello request. Now, the pack-leader needs to send it's
-/// pack-leader-hello back to the client.
-async fn bluefin_packleader_handshake_handler(conn: &mut Connection) -> Result<(), BluefinError> {
-    let type_fields = BluefinTypeFields::new(PacketType::UnencryptedHandshake, 0x0);
-    let security_fields = BluefinSecurityFields::new(true, 0b000_1111);
-
-    // Build handshake header
-    conn.context.packet_number += 1;
-    let mut header = BluefinHeader::new(conn.source_id, conn.dest_id, type_fields, security_fields);
-    header.with_packet_number(conn.context.packet_number);
-
-    // Build and send packet
-    let packet = BluefinPacket::builder().header(header).build();
-    conn.set_bytes_out(packet.serialise());
-
-    if let Err(respond_err) = conn.write().await {
-        return Err(BluefinError::HandshakeError(format!(
-            "Failed to send pack-leader response to client: {}",
-            respond_err
-        )));
+impl<'a> HandshakeHandler<'a> {
+    pub(crate) fn new(
+        conn: &'a mut Connection,
+        incoming_packet: Packet,
+        host: BluefinHost,
+    ) -> Self {
+        Self {
+            conn,
+            incoming_packet,
+            host,
+        }
     }
 
-    // Read and validate client-ack. Let's keep this short so that we don't keep blocking the `Accept` thread
-    match conn.read_with_timeout(Duration::from_millis(100)).await {
-        Ok(packet) => eprintln!("Read client ack packet: {:?}", packet),
-        Err(e) => {
+    pub(crate) async fn handle(&mut self) -> Result<()> {
+        match self.host {
+            BluefinHost::Client => self.bluefin_client_handshake_handler().await,
+            BluefinHost::PackLeader => self.bluefin_packleader_handshake_handler().await,
+            _ => todo!(),
+        }
+    }
+
+    /// We have already parsed the client hello request. Now, the pack-leader needs to send it's
+    /// pack-leader-hello back to the client.
+    async fn bluefin_packleader_handshake_handler(&mut self) -> Result<()> {
+        let header = self.incoming_packet.payload.header;
+
+        // The source (client) is our destination. Connection id's can never be zero.
+        let dest_id = header.source_connection_id;
+        if dest_id == 0x0 {
+            return Err(BluefinError::InvalidHeaderError(
+                "Cannot have connection-id of zero".to_string(),
+            ));
+        }
+        self.conn.dest_id = dest_id;
+
+        // Set packet_number for context
+        self.conn.context.packet_number = header.packet_number + 1;
+
+        let type_fields = BluefinTypeFields::new(PacketType::UnencryptedHandshake, 0x0);
+        let security_fields = BluefinSecurityFields::new(true, 0b000_1111);
+
+        let mut header = BluefinHeader::new(
+            self.conn.source_id,
+            self.conn.dest_id,
+            type_fields,
+            security_fields,
+        );
+        header.with_packet_number(self.conn.context.packet_number);
+
+        // Build and send packet
+        let packet = BluefinPacket::builder().header(header).build();
+        self.conn.set_bytes_out(packet.serialise());
+
+        if let Err(respond_err) = self.conn.write().await {
+            return Err(BluefinError::HandshakeError(format!(
+                "Failed to send pack-leader response to client: {}",
+                respond_err
+            )));
+        }
+
+        // Read and validate client-ack. Let's keep this short so that we don't keep blocking the `Accept` thread
+        if let Err(e) = self.conn.read_with_timeout(Duration::from_secs(2)).await {
             eprintln!("Failed to read client ack.");
             return Err(e);
         }
-    }
-    // conn_read_result.packet.validate(conn)?;
+        // conn_read_result.packet.validate(conn)?;
 
-    Ok(())
-}
-
-async fn bluefin_packfollower_handshake_handler(conn: &mut Connection) -> Result<(), BluefinError> {
-    todo!();
-}
-
-/// Pre-condition:
-///     * Client has sent client-hello
-///     * Pack-leader has sent it's response back to client
-///
-/// This function parses the incoming pack-leader-hello and performs validation. This is
-/// almost identical to the `validate` function in `Packet.rs` except we need to set
-/// connection's destination id (we did not know this value yet until the pack-leader has
-/// responded back with it's pack-leader-hello).
-async fn handle_pack_leader_response(
-    conn: &mut Connection,
-    packet: BluefinPacket,
-) -> Result<(), BluefinError> {
-    // Just get the header; as usual, we don't care about the payload during this part of the handshake
-    let header = packet.header;
-
-    // Verify that the connection id is correct (the packet's dst conn id should be our src id)
-    if header.destination_connection_id != conn.source_id {
-        return Err(BluefinError::InvalidHeaderError(format!(
-            "Pack-leader's dst conn id ({}) != client's id ({})",
-            header.destination_connection_id, conn.source_id
-        )));
+        Ok(())
     }
 
-    // Verify that the packet number is as expected
-    if header.packet_number != conn.context.packet_number + 1 {
-        return Err(BluefinError::InvalidHeaderError(format!(
-            "Pack-leader has incorrect packet number {:#016x}, was expecting {:#016x}",
-            header.packet_number, conn.context.packet_number
-        )));
-    }
+    /// Pre-condition:
+    ///     * Client has sent client-hello
+    ///     * Pack-leader has sent it's response back to client
+    ///
+    /// This function parses the incoming pack-leader-hello and performs validation. This is
+    /// almost identical to the `validate` function in `Packet.rs` except we need to set
+    /// connection's destination id (we did not know this value yet until the pack-leader has
+    /// responded back with it's pack-leader-hello).
+    async fn bluefin_client_handshake_handler(&mut self) -> Result<()> {
+        // Just get the header; as usual, we don't care about the payload during this part of the handshake
+        let header = self.incoming_packet.payload.header;
 
-    conn.context.packet_number += 2;
+        // Verify that the connection id is correct (the packet's dst conn id should be our src id)
+        if header.destination_connection_id != self.conn.source_id {
+            return Err(BluefinError::InvalidHeaderError(format!(
+                "Pack-leader's dst conn id ({}) != client's id ({})",
+                header.destination_connection_id, self.conn.source_id
+            )));
+        }
 
-    // The source (pack-leader) is our destination. Conenction id's can never be zero.
-    let dest_id = header.source_connection_id as u32;
-    if dest_id == 0x0 {
-        return Err(BluefinError::InvalidHeaderError(
-            "Cannot have connection-id of zero".to_string(),
-        ));
-    }
-    conn.dest_id = dest_id;
-    // Validated the pack-leader's response. Ack-back.
-    let ack_packet = conn.get_packet(None).serialise();
-    conn.set_bytes_out(ack_packet);
-    if let Err(_) = conn.write().await {
-        return Err(BluefinError::HandshakeError(
-            "Could not sent pack-leader the client-ack.".to_string(),
-        ));
-    }
-    Ok(())
-}
+        // Verify that the packet number is as expected
+        if header.packet_number != self.conn.context.packet_number + 1 {
+            return Err(BluefinError::InvalidHeaderError(format!(
+                "Pack-leader has incorrect packet number {:#016x}, was expecting {:#016x}",
+                header.packet_number, self.conn.context.packet_number
+            )));
+        }
 
-/*
- * Bluefin clients init the handshake. Therefore, we need to prepare the header and send it
- * to the pack_leader (or whatever we think is the current pack_leader).
- */
-async fn bluefin_client_handshake_handler(conn: &mut Connection) -> Result<(), BluefinError> {
-    Ok(())
+        self.conn.context.packet_number += 2;
+
+        // The source (pack-leader) is our destination. Conenction id's can never be zero.
+        let dest_id = header.source_connection_id as u32;
+        if dest_id == 0x0 {
+            return Err(BluefinError::InvalidHeaderError(
+                "Cannot have connection-id of zero".to_string(),
+            ));
+        }
+        self.conn.dest_id = dest_id;
+        // Validated the pack-leader's response. Ack-back.
+        let ack_packet = self.conn.get_packet(None).serialise();
+        self.conn.set_bytes_out(ack_packet);
+
+        if let Err(_) = self.conn.write().await {
+            return Err(BluefinError::HandshakeError(
+                "Could not sent pack-leader the client-ack.".to_string(),
+            ));
+        }
+        Ok(())
+    }
 }

--- a/src/hosts/pack_leader.rs
+++ b/src/hosts/pack_leader.rs
@@ -1,17 +1,8 @@
-use std::{
-    io::{self, ErrorKind},
-    os::fd::FromRawFd,
-    sync::Arc,
-};
+use std::{os::fd::FromRawFd, sync::Arc};
 
 use crate::{
-    core::{
-        context::{BluefinHost, State},
-        error::BluefinError,
-        packet::BluefinPacket,
-        serialisable::Serialisable,
-    },
-    handshake::handshake::bluefin_handshake_handle,
+    core::context::{BluefinHost, State},
+    handshake::handshake::HandshakeHandler,
     io::{
         buffered_read::BufferedRead,
         manager::{ConnectionManager, Result},
@@ -21,17 +12,13 @@ use crate::{
     tun::device::BluefinDevice,
     utils::common::build_connection_from_packet,
 };
-use etherparse::{Ipv4Header, PacketHeaders};
 use rand::Rng;
 use tokio::fs::File;
 
 const NUMBER_OF_WORKER_THREADS: usize = 2;
 
 pub struct BluefinPackLeader {
-    num_connections: usize,
     file: File,
-    fd: i32,
-    name: String,
     manager: Arc<tokio::sync::Mutex<ConnectionManager>>,
     spawned_read_thread: bool,
 }
@@ -85,46 +72,18 @@ impl BluefinPackLeaderBuilder {
         let manager = ConnectionManager::new();
 
         BluefinPackLeader {
-            num_connections: 0,
-            fd,
             file,
             manager: Arc::new(tokio::sync::Mutex::new(manager)),
-            name,
             spawned_read_thread: false,
         }
     }
 }
 
 impl BluefinPackLeader {
-    /// Trying to validate an incoming client-hello request. Try to parse and deserialise the request
-    /// and validate its contents. If everything looks good then proceed with handshake, else return
-    /// err.
-    fn validate_client_request(&self, conn: &mut Connection, bytes: &[u8]) -> Result<()> {
-        let packet = BluefinPacket::deserialise(bytes)?;
-        // Just get the header; don't really care if there is a payload or not
-        let header = packet.header;
-
-        // The source (client) is our destination. Connection id's can never be zero.
-        let dest_id = header.source_connection_id as u32;
-        if dest_id == 0x0 {
-            return Err(BluefinError::InvalidHeaderError(
-                "Cannot have connection-id of zero".to_string(),
-            ));
-        }
-        conn.dest_id = dest_id;
-
-        // Set packet_number for context
-        conn.context.packet_number = header.packet_number;
-        Ok(())
-    }
-
-    /// Pack-leader accepts a bluefin connection request. This function return an `Accept` future
-    /// which asynchronously reads incoming bytes. Upon a valid bluefin handshake request packet,
-    /// and successful handshake completion, the future registers and creates a `Connection` instance.
+    /// Pack-leader accepts a bluefin connection request. Upon first invocation, this function spawns
+    /// a number of read thread workers. This function waits asynchronously for a client hello, registers
+    /// the relevant connection buffers and completes the handshake.
     pub async fn accept(&mut self) -> Result<Connection> {
-        // Receive initial connection status
-        let source_id: u32 = rand::thread_rng().gen();
-
         // Spawn some read worker threads
         if !self.spawned_read_thread {
             for _ in 0..NUMBER_OF_WORKER_THREADS {
@@ -149,15 +108,18 @@ impl BluefinPackLeader {
             accept_worker.run().await;
         });
 
-        let key = format!("0_{}", source_id);
+        // Generate source id
+        let source_id: u32 = rand::thread_rng().gen();
+        let temp_key = format!("0_{}", source_id);
 
         // Lock acquired
         let buffer = {
             let mut manager = self.manager.lock().await;
-            manager.register_new_accept_connection(&key)
+            manager.register_new_accept_connection(&temp_key)
         };
         // Lock released
 
+        // Await for client-hello
         let read = BufferedRead::new(Arc::clone(&buffer));
         let packet = read.await;
 
@@ -171,6 +133,7 @@ impl BluefinPackLeader {
             Arc::clone(&buffer),
             self.file.try_clone().await.unwrap(),
         );
+        let key = format!("{}_{}", conn.dest_id, conn.source_id);
 
         // Lock acquired
         {
@@ -180,67 +143,12 @@ impl BluefinPackLeader {
         }
         // Lock released
 
-        bluefin_handshake_handle(&mut conn).await?;
+        let mut handshake_handler =
+            HandshakeHandler::new(&mut conn, packet, BluefinHost::PackLeader);
+        handshake_handler.handle().await?;
+
+        conn.context.state = State::Ready;
 
         Ok(conn)
-    }
-
-    async fn parse_and_set_header_info(
-        &mut self,
-        conn: &mut Connection,
-        bytes: &[u8],
-    ) -> io::Result<()> {
-        match PacketHeaders::from_ip_slice(&bytes[4..]) {
-            // TODO: Is this the right error?
-            Err(_) => Err(io::Error::from(ErrorKind::Unsupported)),
-            Ok(value) => {
-                let ip_header_len = value.ip.unwrap().header_len();
-                let (ip_header, _) = Ipv4Header::from_slice(&bytes[4..ip_header_len + 4]).unwrap();
-
-                // Not udp. Pass.
-                if ip_header.protocol != 0x11 {
-                    return Err(io::Error::new(
-                        ErrorKind::Unsupported,
-                        format!(
-                            "Cannot accept non-UDP IP packet (found protocol {:?})",
-                            ip_header.protocol
-                        ),
-                    ));
-                }
-
-                let udp_header = value.transport.unwrap().udp().unwrap();
-                let udp_header_len = udp_header.header_len();
-
-                conn.source_ip = Some(ip_header.source);
-                conn.destination_ip = Some(ip_header.destination);
-                conn.source_port = Some(udp_header.source_port);
-                conn.destination_port = Some(udp_header.destination_port);
-
-                // Validate bluefin packet
-                if let Err(validation_error) =
-                    // Throw away the header leaving only a bluefin packet
-                    self.validate_client_request(
-                        conn,
-                        &bytes[4 + ip_header_len + udp_header_len..],
-                    )
-                {
-                    // TODO: Send error response.
-                    conn.context.state = State::Error;
-                    return Err(io::Error::new(ErrorKind::InvalidData, validation_error));
-                }
-
-                // Proceed with handshake
-                if let Err(bluefin_err) = bluefin_handshake_handle(conn).await {
-                    conn.write_error_message(bluefin_err.to_string().as_bytes())
-                        .await?;
-                    return Err(io::Error::new(
-                        ErrorKind::Unsupported,
-                        format!("Aborting connection. {:?}", bluefin_err),
-                    ));
-                }
-
-                Ok(())
-            }
-        }
     }
 }

--- a/src/io/buffered_read.rs
+++ b/src/io/buffered_read.rs
@@ -11,7 +11,7 @@ use crate::core::packet::Packet;
 use super::manager::ConnectionBuffer;
 
 pub struct BufferedRead {
-    /// Unique id per buffered read request
+    /// Unique id per buffered read request, mostly used for debugging purposes
     id: u32,
     /// This connection's buffer
     buffer: Arc<Mutex<ConnectionBuffer>>,

--- a/src/io/manager.rs
+++ b/src/io/manager.rs
@@ -104,7 +104,12 @@ impl ConnectionManager {
         Ok(())
     }
 
-    pub(crate) fn buffer_unhandled_client_hello(&mut self, packet: Packet) -> Result<()> {
+    /// Buffers in an unhandled client hello `packet`. This happens when we receive a client-hello
+    /// but we can't find any pending `Accept` requests in `accept_buffer_map`. We store this for
+    /// later use incase another `Accept` request comes and can potentially pick up this unhandled
+    /// packet. In order to avoid burdening memory, we only buffer a limited number of these packets.
+    /// TODO: Add TTL for these packets
+    fn buffer_unhandled_client_hello(&mut self, packet: Packet) -> Result<()> {
         if self.unhandled_client_hellos.len() >= MAX_UNHANDLED_NEW_CONNECTION_REQ {
             return Err(BluefinError::BufferFullError);
         }

--- a/src/io/read.rs
+++ b/src/io/read.rs
@@ -48,7 +48,7 @@ impl AcceptWorker {
     /// were able to wake up an accept then our job is done and we can exit.
     pub(crate) async fn run(&self) {
         for _ in 0..self.max_number_tries {
-            sleep(Duration::from_secs(1)).await;
+            sleep(Duration::from_secs(2)).await;
 
             // Lock acquired
             let mut manager = self.manager.lock().await;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use bluefin::hosts::pack_leader::BluefinPackLeader;
 #[tokio::main]
 async fn main() {
     let mut pack_leader = BluefinPackLeader::builder()
-        .name("utun7".to_string())
+        .name("utun8".to_string())
         .bind_address("192.168.55.2".to_string())
         .netmask("255.255.255.0".to_string())
         .build();
@@ -14,12 +14,6 @@ async fn main() {
             if let Ok(conn) = conn_res {
                 eprintln!("Received: {conn}");
             }
-            // while let Ok(mut stream) = conn.accept_stream().await {
-            //     tokio::spawn(async move {
-            //         eprintln!("Stream: {}", stream.id);
-            //         stream.receive().await;
-            //     });
-            // }
         });
     }
 }

--- a/src/tun/device.rs
+++ b/src/tun/device.rs
@@ -3,7 +3,7 @@ use std::net::Ipv4Addr;
 use std::os::fd::IntoRawFd;
 use std::process::Command;
 use tun::platform::Device;
-use tun_tap::{Iface, Mode};
+use tun_tap::Iface;
 
 // This only exists because it's a pain to work with tun/tap devices
 // on Mac OS

--- a/src/tun/device.rs
+++ b/src/tun/device.rs
@@ -3,7 +3,7 @@ use std::net::Ipv4Addr;
 use std::os::fd::IntoRawFd;
 use std::process::Command;
 use tun::platform::Device;
-use tun_tap::Iface;
+use tun_tap::{Iface, Mode};
 
 // This only exists because it's a pain to work with tun/tap devices
 // on Mac OS


### PR DESCRIPTION
* Updated docs to reflect current state
* Lots of code cleanup
* Fixed bug where we re-registered the `temp_key` for the pack leader after the client-hello was found instead of registering the 'real' connection key
* Verified working handshake between client <-> pack-leader
* Re-worked the handshake handling
* Addresses #6 